### PR TITLE
Handle stdout being missing from Command objects in Django 1.2

### DIFF
--- a/stackhelper/management/commands/stack_diff.py
+++ b/stackhelper/management/commands/stack_diff.py
@@ -15,6 +15,10 @@ class Command(BaseCommand):
     help = 'generates configuration files in the chosen directory'
 
     def handle(self, *args, **options):
+
+        if not hasattr(self, 'stdout'):
+            self.stdout = sys.stdout
+
         if len(args) != 1:
             self.print_help(sys.argv[0], sys.argv[1])
             return
@@ -25,12 +29,8 @@ class Command(BaseCommand):
                 "stack_templates"
             )
             for path, d in diff(template_path, outputdir):
-                if hasattr(self, 'stdout'):
-                    self.stdout.write(path)
-                    self.stdout.write(d)
-                else:
-                    print(path)
-                    print(d)
+                self.stdout.write(path)
+                self.stdout.write(d)
 
     def project_root(self):
         """ Locate the root of the django project.

--- a/stackhelper/management/commands/stack_diff.py
+++ b/stackhelper/management/commands/stack_diff.py
@@ -1,8 +1,13 @@
+from __future__ import print_function
+
+import os
+import sys
+
 from django.core.management.base import BaseCommand
-import os, sys
 from django.conf import settings
 
 from stackhelper import diff
+
 
 class Command(BaseCommand):
 
@@ -15,19 +20,21 @@ class Command(BaseCommand):
             return
         else:
             outputdir = args[0]
-            template_path = os.path.join(self.project_root(), "stack_templates")        
+            template_path = os.path.join(
+                self.project_root(),
+                "stack_templates"
+            )
             for path, d in diff(template_path, outputdir):
-                self.stdout.write(path)
-                self.stdout.write(d)
+                if hasattr(self, 'stdout'):
+                    self.stdout.write(path)
+                    self.stdout.write(d)
+                else:
+                    print(path)
+                    print(d)
 
     def project_root(self):
-        """ Locate the root of the django project. There is probably a much better way of doing this. """
-        # possibly put templates in installed applications and loop through them?
+        """ Locate the root of the django project.
+        There is probably a much better way of doing this. """
+        # possibly put templates in installed applications
+        # and loop through them?
         return __import__(settings.SETTINGS_MODULE).__path__[0]
-
-
-
-
-
-
-

--- a/stackhelper/management/commands/stack_generate.py
+++ b/stackhelper/management/commands/stack_generate.py
@@ -1,9 +1,14 @@
-from django.core.management.base import BaseCommand
-import os, sys
-from django.conf import settings
+from __future__ import print_function
+
+import os
+import sys
 from optparse import make_option
 
+from django.core.management.base import BaseCommand
+from django.conf import settings
+
 from stackhelper import generate
+
 
 class Command(BaseCommand):
 
@@ -24,21 +29,20 @@ class Command(BaseCommand):
             return
         else:
             outputdir = args[0]
-            
-        self.stdout.write("Writing configuration files to %r" % outputdir)
+
+        message = "Writing configuration files to %r" % outputdir
+        if hasattr(self, 'stdout'):
+            self.stdout.write(message)
+        else:
+            print(message)
         if not os.path.exists(outputdir):
             os.mkdir(outputdir)
-        template_path = os.path.join(self.project_root(), "stack_templates")        
+        template_path = os.path.join(self.project_root(), "stack_templates")
         generate(template_path, outputdir, options['force'])
 
     def project_root(self):
-        """ Locate the root of the django project. There is probably a much better way of doing this. """
-        # possibly put templates in installed applications and loop through them?
+        """ Locate the root of the django project.
+        There is probably a much better way of doing this. """
+        # possibly put templates in installed applications
+        # and loop through them?
         return __import__(settings.SETTINGS_MODULE).__path__[0]
-
-
-
-
-
-
-

--- a/stackhelper/management/commands/stack_generate.py
+++ b/stackhelper/management/commands/stack_generate.py
@@ -22,6 +22,10 @@ class Command(BaseCommand):
     )
 
     def handle(self, *args, **options):
+
+        if not hasattr(self, 'stdout'):
+            self.stdout = sys.stdout
+
         if len(args) == 0:
             outputdir = os.path.join(sys.prefix, "etc")
         elif len(args) > 1:
@@ -30,11 +34,7 @@ class Command(BaseCommand):
         else:
             outputdir = args[0]
 
-        message = "Writing configuration files to %r" % outputdir
-        if hasattr(self, 'stdout'):
-            self.stdout.write(message)
-        else:
-            print(message)
+        self.stdout.write("Writing configuration files to %r" % outputdir)
         if not os.path.exists(outputdir):
             os.mkdir(outputdir)
         template_path = os.path.join(self.project_root(), "stack_templates")


### PR DESCRIPTION
Django Command objects do not have `stdout` in 1.2.

Check for presence and switch to using print() if that's the case.
